### PR TITLE
Fix CMake to allow building with catkin_tools

### DIFF
--- a/bezier_application/CMakeLists.txt
+++ b/bezier_application/CMakeLists.txt
@@ -11,6 +11,7 @@ catkin_package(CATKIN_DEPENDS bezier_library)
 
 include_directories(${VTK_USE_FILE} ${PCL_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS}) # Order matters!
 add_definitions(${PCL_DEFINITIONS} ${VTK_DEFINITIONS})
+link_directories(${catkin_LIBRARY_DIRS})
 
 add_executable (bezier_application src/bezier_application.cpp)
 set_property(TARGET bezier_application APPEND_STRING PROPERTY COMPILE_FLAGS -Wall)

--- a/bezier_library/CMakeLists.txt
+++ b/bezier_library/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 2.8.3)
-set (CMAKE_CXX_FLAGS "-fPIC")
 project(bezier_library)
 
 find_package(catkin REQUIRED COMPONENTS roscpp)
@@ -16,7 +15,7 @@ include_directories(include ${VTK_USE_FILE} ${PCL_INCLUDE_DIRS} ${catkin_INCLUDE
 add_definitions(${PCL_DEFINITIONS}) # ${VTK_DEFINITIONS} crashes compilation
 
 add_library (bezier_library_obj OBJECT src/bezier_library.cpp)
-set_property(TARGET bezier_library_obj APPEND_STRING PROPERTY COMPILE_FLAGS -Wall)
+set_property(TARGET bezier_library_obj APPEND_STRING PROPERTY COMPILE_FLAGS "-fPIC -Wall")
 add_library (${PROJECT_NAME} $<TARGET_OBJECTS:bezier_library_obj>)
 
 install(


### PR DESCRIPTION
Fixes #46. Allows building with [catkin_tools](http://catkin-tools.readthedocs.org/en/latest/) without error.

```
set (CMAKE_CXX_FLAGS "-fPIC")
```

Is very bad because it replaces (erase) every flag added to `CMAKE_CXX_FLAGS` by `-fPIC`

@KevinBollore ready for review
