### PR TITLE
Revert "Add missing dependency on pcl_conversions"

### DIFF
--- a/bezier_application/CMakeLists.txt
+++ b/bezier_application/CMakeLists.txt
@@ -2,12 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bezier_application)
 
 ## Find catkin and any catkin packages
-find_package(catkin REQUIRED COMPONENTS bezier_library
-                                        moveit_ros_planning_interface
-                                        pcl_ros
-                                        roscpp
-                                        tf tf_conversions
-                                        visualization_msgs)
+find_package(catkin REQUIRED COMPONENTS bezier_library moveit_ros_planning_interface roscpp tf tf_conversions visualization_msgs)
 find_package(PCL 1.8.0 REQUIRED)
 find_package(VTK 7.0 REQUIRED COMPONENTS vtkFiltersHybrid NO_MODULE)
 

--- a/bezier_application/package.xml
+++ b/bezier_application/package.xml
@@ -11,7 +11,6 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>bezier_library</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>visualization_msgs</build_depend>
@@ -20,5 +19,4 @@
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>bezier_library</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
 </package>

--- a/bezier_application/src/bezier_application.cpp
+++ b/bezier_application/src/bezier_application.cpp
@@ -4,7 +4,6 @@
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <eigen_conversions/eigen_msg.h>
-#include <pcl_ros/point_cloud.h>
 #include <moveit/move_group_interface/move_group.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <tf/transform_listener.h>

--- a/bezier_library/CMakeLists.txt
+++ b/bezier_library/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bezier_library)
 
-find_package(catkin REQUIRED COMPONENTS pcl_conversions
-                                        roscpp)
+find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(PCL 1.8.0 REQUIRED)
 find_package(VTK 7.0 REQUIRED) # You need https://gitlab.kitware.com/vtk/vtk/merge_requests/213
 include(${VTK_USE_FILE})

--- a/bezier_library/package.xml
+++ b/bezier_library/package.xml
@@ -11,10 +11,8 @@
 
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>
-  <build_depend>pcl_conversions</build_depend>
 
   <exec_depend>roscpp</exec_depend>
-  <exec_depend>pcl_conversions</exec_depend>
 
   <export>
     <rosdoc config="doc/rosdoc.yaml" />


### PR DESCRIPTION
This reverts commit f5db27b47364254cf9b1d0feb0be09b3528ff5ec.
Fixes #60 

It seems that this commit is responsible for the crashes we have experienced.
@KevinBollore & @Nandite please check that this solves our issue.

Let's wait for Travis and see if it still builds, both `catkin_make` and `catkin build` works locally.
