### PR TITLE
Use Isometry instead of Affine for RViz visual tools compatibility

### DIFF
--- a/bezier_application/src/painting.cpp
+++ b/bezier_application/src/painting.cpp
@@ -89,7 +89,7 @@ int main(int argc,
   bezier_planner->setMeshesPublishers(cad_mesh_pub, dilated_mesh_pub);
   bezier_planner->waitForRvizVisualToolsSubscriber();
 
-  EigenSTL::vector_Affine3d way_points_vector;
+  EigenSTL::vector_Isometry3d way_points_vector;
   std::string error_message;
   std::vector<bool> is_grinding_pose;
   error_message = bezier_planner->generateTrajectory(way_points_vector, is_grinding_pose);
@@ -110,7 +110,7 @@ int main(int argc,
 
   // Copy the vector of Eigen poses into a vector of ROS poses
   std::vector<geometry_msgs::Pose> way_points_msg;
-  for (Eigen::Affine3d eigen_pose : way_points_vector)
+  for (Eigen::Isometry3d eigen_pose : way_points_vector)
   {
     //ROS_INFO_STREAM("Pose : " << std::endl << eigen_pose.matrix());
     geometry_msgs::Pose tmp;

--- a/bezier_application/src/surfacing.cpp
+++ b/bezier_application/src/surfacing.cpp
@@ -99,7 +99,7 @@ int main(int argc,
   bezier_planner->setMeshesPublishers(cad_mesh_pub, dilated_mesh_pub);
   bezier_planner->waitForRvizVisualToolsSubscriber();
 
-  EigenSTL::vector_Affine3d way_points_vector;
+  EigenSTL::vector_Isometry3d way_points_vector;
   std::string error_message;
   std::vector<bool> is_grinding_pose;
   error_message = bezier_planner->generateTrajectory(way_points_vector, is_grinding_pose);
@@ -120,7 +120,7 @@ int main(int argc,
 
   // Copy the vector of Eigen poses into a vector of ROS poses
   std::vector<geometry_msgs::Pose> way_points_msg;
-  for (Eigen::Affine3d eigen_pose : way_points_vector)
+  for (Eigen::Isometry3d eigen_pose : way_points_vector)
   {
     //ROS_INFO_STREAM("Pose : " << std::endl << eigen_pose.matrix());
     geometry_msgs::Pose tmp;

--- a/bezier_library/include/bezier_library/bezier_grinding_surfacing.hpp
+++ b/bezier_library/include/bezier_library/bezier_grinding_surfacing.hpp
@@ -47,11 +47,11 @@ public:
   void setMeshesPublishers(std::shared_ptr<ros::Publisher> &input_mesh_publisher,
                            std::shared_ptr<ros::Publisher> &dilated_mesh_publisher);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const bool display_markers = true);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const double grinding_disk_machining_width,
                                  const unsigned covering_percentage,
@@ -85,7 +85,7 @@ public:
    * @param[in] end_point is the end point of the line
    * @param[in] number_of_poses is the number of poses to be generated
    */
-  void generateIntermediatePoseOnLine(EigenSTL::vector_Affine3d &poses,
+  void generateIntermediatePoseOnLine(EigenSTL::vector_Isometry3d &poses,
                                       const Eigen::Vector3d &start_point,
                                       const Eigen::Vector3d &end_point,
                                       const unsigned number_of_poses);
@@ -114,10 +114,10 @@ private:
   vtkSmartPointer<vtkPolyData> extrication_mesh;
 
   // Vector of generated poses (trajectories)
-  std::vector<EigenSTL::vector_Affine3d> grinding_trajectories;
-  std::vector<EigenSTL::vector_Affine3d> extrication_trajectories;
-  std::vector<EigenSTL::vector_Affine3d> start_intermediate_poses_trajectories;
-  std::vector<EigenSTL::vector_Affine3d> end_intermediate_poses_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> grinding_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> extrication_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> start_intermediate_poses_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> end_intermediate_poses_trajectories;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/bezier_library/include/bezier_library/bezier_library.hpp
+++ b/bezier_library/include/bezier_library/bezier_library.hpp
@@ -109,7 +109,7 @@ public:
    * @return An empty string on success, an error string otherwise
    * @note trajectory and is_grinding_pose are always the same size
    */
-  std::string virtual generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string virtual generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                          std::vector<bool> &is_grinding_pose,
                                          bool display_markers) = 0;
 
@@ -218,7 +218,7 @@ protected:
    * @param display_normals display Z normal
    * @param display_labels display pose ID
    */
-  void displayTrajectory(const EigenSTL::vector_Affine3d &trajectory,
+  void displayTrajectory(const EigenSTL::vector_Isometry3d &trajectory,
                          rviz_visual_tools::colors color,
                          const bool display_normals = false,
                          const bool display_labels = false);
@@ -284,7 +284,7 @@ protected:
    * @param lean_angle_axis
    * @param angle_value in radians
    */
-  void applyLeanAngle(Eigen::Affine3d &pose,
+  void applyLeanAngle(Eigen::Isometry3d &pose,
                       const AXIS_OF_ROTATION lean_angle_axis,
                       const double angle_value);
 
@@ -296,13 +296,13 @@ protected:
    * @return True if successful, false otherwise
    */
   bool generateRobotPosesAlongStripper(const vtkSmartPointer<vtkStripper> &line,
-                                       EigenSTL::vector_Affine3d &trajectory);
+                                       EigenSTL::vector_Isometry3d &trajectory);
 
   /**
    * Invert the X axis orientation by inverting the X and Y vectors of the pose
    * @param[in] line to be modified
    */
-  void invertXAxisOfPoses(EigenSTL::vector_Affine3d &line);
+  void invertXAxisOfPoses(EigenSTL::vector_Isometry3d &line);
 
   /**
    * Filters points that are too close from each others
@@ -327,7 +327,7 @@ protected:
                                    const Eigen::Vector3d &last_point,
                                    const Eigen::Vector3d &last_point_normal,
                                    const Eigen::Vector4d &plane_equation,
-                                   EigenSTL::vector_Affine3d &trajectory);
+                                   EigenSTL::vector_Isometry3d &trajectory);
 
   /**
    * Harmonize grinding/extrication lines orientation.
@@ -335,7 +335,7 @@ protected:
    * @param[in] direction_ref is direction vector reference
    * @return True if line was reversed, false otherwise
    */
-  bool harmonizeLineOrientation(EigenSTL::vector_Affine3d &poses,
+  bool harmonizeLineOrientation(EigenSTL::vector_Isometry3d &poses,
                                 const Eigen::Vector3d &direction_ref);
 
   /**

--- a/bezier_library/include/bezier_library/bezier_painting.hpp
+++ b/bezier_library/include/bezier_library/bezier_painting.hpp
@@ -46,11 +46,11 @@ public:
   void setMeshesPublishers(std::shared_ptr<ros::Publisher> &input_mesh_publisher,
                            std::shared_ptr<ros::Publisher> &dilated_mesh_publisher);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const bool display_markers = true);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const double painting_cone_width,
                                  const unsigned covering_percentage,

--- a/bezier_library/include/bezier_library/bezier_tire_machining.hpp
+++ b/bezier_library/include/bezier_library/bezier_tire_machining.hpp
@@ -40,11 +40,11 @@ public:
   void setMeshesPublishers(std::shared_ptr<ros::Publisher> &input_mesh_publisher,
                            std::shared_ptr<ros::Publisher> &dilated_mesh_publisher);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const bool display_markers = true);
 
-  std::string generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+  std::string generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                  std::vector<bool> &is_grinding_pose,
                                  const double tool_length,
                                  const double tool_radius,

--- a/bezier_library/src/bezier_painting.cpp
+++ b/bezier_library/src/bezier_painting.cpp
@@ -38,7 +38,7 @@ void BezierPainting::setMeshesPublishers(std::shared_ptr<ros::Publisher> &input_
     displayMesh(input_mesh_pub_, std::string("file://" + input_mesh_absolute_path_), 0.3, 0.2, 0.2);
 }
 
-std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+std::string BezierPainting::generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                                std::vector<bool> &is_grinding_pose,
                                                const bool display_markers)
 {
@@ -89,7 +89,7 @@ std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajec
 
   // Compute the vector used to harmonize all the trajectories directions and display it
   Eigen::Vector3d direction_reference(slicing_orientation_.cross(global_mesh_normal));
-  Eigen::Affine3d pose_dir_reference(Eigen::Affine3d::Identity());
+  Eigen::Isometry3d pose_dir_reference(Eigen::Isometry3d::Identity());
   double centroid[3];
   centroid[0] = input_meshes_[PAINTING_MESH]->GetCenter()[0];
   centroid[1] = input_meshes_[PAINTING_MESH]->GetCenter()[1];
@@ -104,11 +104,11 @@ std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajec
   visual_tools_->publishText(pose_dir_reference, "Direction reference", rviz_visual_tools::GREEN,
                              rviz_visual_tools::SMALL, false);
 
-  std::vector<EigenSTL::vector_Affine3d> grinding_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> grinding_trajectories;
   for (std::vector<vtkSmartPointer<vtkStripper> >::iterator it(grinding_strippers.begin());
       it != grinding_strippers.end(); ++it)
   {
-    EigenSTL::vector_Affine3d traj;
+    EigenSTL::vector_Isometry3d traj;
     if (!generateRobotPosesAlongStripper(*it, traj))
     {
       ROS_WARN_STREAM("BezierPainting::generateTrajectory: Could not generate robot poses for grinding trajectory");
@@ -126,7 +126,7 @@ std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajec
   is_grinding_pose.push_back(false);
 
   unsigned reverse_index(0);
-  for (EigenSTL::vector_Affine3d & grinding_traj : grinding_trajectories)
+  for (EigenSTL::vector_Isometry3d & grinding_traj : grinding_trajectories)
   {
     // Zig Zag trajectory
     if (reverse_index % 2 != 0)
@@ -135,7 +135,7 @@ std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajec
       invertXAxisOfPoses(grinding_traj);
     }
     reverse_index++;
-    for (Eigen::Affine3d grinding_pose : grinding_traj)
+    for (Eigen::Isometry3d grinding_pose : grinding_traj)
     {
       trajectory.push_back(grinding_pose);
       is_grinding_pose.push_back(true);
@@ -145,7 +145,7 @@ std::string BezierPainting::generateTrajectory(EigenSTL::vector_Affine3d &trajec
   unsigned index(0);
   if (display_markers)
   {
-    for (EigenSTL::vector_Affine3d traj : grinding_trajectories)
+    for (EigenSTL::vector_Isometry3d traj : grinding_trajectories)
     {
       if (index > 11)
         index = 0;

--- a/bezier_library/src/bezier_tire_machining.cpp
+++ b/bezier_library/src/bezier_tire_machining.cpp
@@ -40,7 +40,7 @@ void BezierTireMachining::setMeshesPublishers(std::shared_ptr<ros::Publisher> &i
     displayMesh(input_mesh_pub_, std::string("file://" + input_mesh_absolute_path_), 0.3, 0.2, 0.2);
 }
 
-std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &trajectory,
+std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Isometry3d &trajectory,
                                                     std::vector<bool> &is_machining_pose,
                                                     const bool display_markers)
 {
@@ -117,7 +117,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
   if (direction_reference.x() > 0)
     direction_reference = -direction_reference;
 
-  Eigen::Affine3d pose_dir_reference(Eigen::Affine3d::Identity());
+  Eigen::Isometry3d pose_dir_reference(Eigen::Isometry3d::Identity());
   double centroid[3];
   centroid[0] = dilated_mesh->GetCenter()[0];
   centroid[1] = dilated_mesh->GetCenter()[1];
@@ -133,7 +133,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
                              rviz_visual_tools::SMALL,
                              false);
 
-  std::vector<EigenSTL::vector_Affine3d> machining_trajectories;
+  std::vector<EigenSTL::vector_Isometry3d> machining_trajectories;
   for (std::vector<vtkSmartPointer<vtkStripper> >::iterator it(machining_strippers.begin());
       it != machining_strippers.end(); ++it)
   {
@@ -146,7 +146,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
         continue;
       }
 
-    EigenSTL::vector_Affine3d traj;
+    EigenSTL::vector_Isometry3d traj;
     if (!generateRobotPosesAlongStripper(*it, traj))
     {
       ROS_WARN_STREAM(
@@ -186,7 +186,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
   is_machining_pose.push_back(false);
 
   unsigned reverse_index(0);
-  for (EigenSTL::vector_Affine3d & machining_traj : machining_trajectories)
+  for (EigenSTL::vector_Isometry3d & machining_traj : machining_trajectories)
   {
     // Zig Zag trajectory
     if (reverse_index % 2 != 0)
@@ -195,7 +195,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
       // Do NOT modify orientation!
     }
     reverse_index++;
-    for (Eigen::Affine3d machining_pose : machining_traj)
+    for (Eigen::Isometry3d machining_pose : machining_traj)
     {
       trajectory.push_back(machining_pose);
       is_machining_pose.push_back(true);
@@ -205,7 +205,7 @@ std::string BezierTireMachining::generateTrajectory(EigenSTL::vector_Affine3d &t
   unsigned index(0);
   if (display_markers)
   {
-    for (EigenSTL::vector_Affine3d traj : machining_trajectories)
+    for (EigenSTL::vector_Isometry3d traj : machining_trajectories)
     {
       if (index > 11)
         index = 0;


### PR DESCRIPTION
RViz visual tools now uses Isometry instead of Affine. This pull request just makes it compatible with the new API