### PR TITLE
Add catkin dependency on PCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ catkin_package(
   roscpp
   rviz_visual_tools
   DEPENDS
+  PCL
   VTK
 )
 


### PR DESCRIPTION
Fixes problem described in https://github.com/ros-industrial-consortium/bezier_examples/pull/4